### PR TITLE
Adding compatibility for yajl-2 wrt issue #5

### DIFF
--- a/jsonstreamer/yajl/parse.py
+++ b/jsonstreamer/yajl/parse.py
@@ -20,7 +20,7 @@ def load_lib():
     loads and return the yajl shared object lib
     :return: cdll object
     """
-    for each in '', '.so', '.dylib':
+    for each in '', '.so', '.dylib', '.so.2':
         yajlso = 'libyajl{}'.format(each)
         try:
             return cdll.LoadLibrary(yajlso)


### PR DESCRIPTION
... wrt issue #5 : Trouble using `jsonstreamer` with `yajl-2` on Ubuntu 14.04